### PR TITLE
fix: configure npm registry auth for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: 20
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - run: pnpm install --frozen-lockfile
 
@@ -34,3 +35,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.npm_token }}
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}


### PR DESCRIPTION
- Add registry-url to setup-node action to properly configure .npmrc
- Add NODE_AUTH_TOKEN env var which setup-node expects for authentication

https://claude.ai/code/session_0111MWAPm3P9DgHovMZU7LSF