### PR TITLE
feat: switch to npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -16,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
@@ -34,5 +38,4 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.npm_token }}
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
- Add id-token: write permission for OIDC authentication
- Remove NPM_TOKEN/NODE_AUTH_TOKEN (no longer needed with OIDC)
- Enable NPM_CONFIG_PROVENANCE for signed attestations
- Upgrade to node 22 for npm 11.x with OIDC support
- Add contents: write and pull-requests: write permissions

This eliminates the need for npm tokens entirely by using GitHub Actions' built-in OIDC identity for authentication.

https://claude.ai/code/session_0111MWAPm3P9DgHovMZU7LSF