### PR TITLE
fix: upgrade npm to 11.x for OIDC trusted publishing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm run build
@@ -38,4 +41,3 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Node.js 22 bundles npm 10.x, but OIDC trusted publishing requires npm 11.5.1+. Add explicit npm upgrade step to ensure compatibility.

Also removes NPM_CONFIG_PROVENANCE as OIDC trusted publishing handles provenance automatically.

https://claude.ai/code/session_0111MWAPm3P9DgHovMZU7LSF