### PR TITLE
fix: correct repo url in package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,4 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ""

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/bradmcgonigle/react-nhl-logos.git"
+    "url": "https://github.com/BradMcGonigle/react-nhl-logos.git"
   },
   "author": "Brad McGonigle",
   "license": "ISC",


### PR DESCRIPTION
The new npm trusted platform publishing requires the url to be exact including case-sensitivity. 